### PR TITLE
Allocate 5GB of memory after 2 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,11 +145,11 @@ jobs:
           environment:
             AWS_DEFAULT_REGION: eu-west-1
 
-      - run:
-          name: Update cloudformation stack us-east-1
-          command: DOCKER_TAG="$CIRCLE_SHA1" .circleci/do-exclusively.sh --branch $CIRCLE_BRANCH make deploy-stack
-          environment:
-            AWS_DEFAULT_REGION: us-east-1
+      # - run:
+      #     name: Update cloudformation stack us-east-1
+      #     command: DOCKER_TAG="$CIRCLE_SHA1" .circleci/do-exclusively.sh --branch $CIRCLE_BRANCH make deploy-stack
+      #     environment:
+      #       AWS_DEFAULT_REGION: us-east-1
 
   security-monitor:
     executor: golang-node

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -43,6 +43,19 @@ func main() {
 	}
 	server := server.Server(listenAddress, &httpClient)
 
+	go func() {
+		timeout := time.After(time.Duration(2) * time.Minute)
+		select {
+		case <-timeout:
+			fmt.Println("Start allocating 5GB of memory")
+			ballast := make([]byte, 10<<29)
+			for i := 0; i < len(ballast); i++ {
+				ballast[i] = byte('A')
+			}
+			fmt.Println("Done allocating 5GB of memory")
+		}
+	}()
+
 	done := make(chan bool)
 
 	go func() {


### PR DESCRIPTION
This should allow the service to reach a steady state in ECS.

This is to chaos test the ECS instance behaviour when a task uses more memory than is available.

See https://docs.google.com/spreadsheets/d/1w0T4fcoSSu7An8FRy4GuJzA1fHkSVZmi5QdKKIRf67A/edit?ts=5d135ea5#gid=0
and 
https://blog.twitch.tv/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap-26c2462549a2 for docs on allocating memory this way.